### PR TITLE
Add PostgreSQL with pgvector to Docker Compose

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  postgres-dev:
+    image: pgvector/pgvector:pg15
+    container_name: chatbot-postgres-dev
+    environment:
+      POSTGRES_DB: chatbot_dev
+      POSTGRES_USER: chatbot_user
+      POSTGRES_PASSWORD: dev_password_123
+      POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --locale=en_US.UTF-8"
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U chatbot_user -d chatbot_dev"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+networks:
+  default:
+    name: chatbot-network


### PR DESCRIPTION
Create basic Docker Compose file with pgvector-enabled PostgreSQL for development. Single container, no volumes yet.

**Acceptance Criteria:**
- [ ] `docker-compose.yml` file created in project root
- [ ] Uses `pgvector/pgvector:pg15` image
- [ ] Container named `chatbot-postgres-dev`
- [ ] Exposes port 5432
- [ ] Environment: `POSTGRES_DB=chatbot_dev`, `POSTGRES_USER=chatbot_user`, `POSTGRES_PASSWORD=dev_password_123`
- [ ] `docker-compose up -d` starts successfully
- [ ] Can connect: `psql -h localhost -U chatbot_user -d chatbot_dev`