### PR TITLE
Configure persistent volume for development PostgreSQL data

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -9,12 +9,18 @@ services:
       POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --locale=en_US.UTF-8"
     ports:
       - "5432:5432"
+    volumes:
+      - postgres_data_dev:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U chatbot_user -d chatbot_dev"]
       interval: 5s
       timeout: 5s
       retries: 5
     restart: unless-stopped
+
+volumes:
+  postgres_data_dev:
+    name: chatbot_postgres_dev
 
 networks:
   default:


### PR DESCRIPTION
**Description:**
Add named volume to Docker Compose so database data persists between container restarts.

**Acceptance Criteria:**
- [x] Volume `postgres_data_dev` defined in `docker-compose.yml`
- [x] Volume mounted to `/var/lib/postgresql/data`
- [x] Data persists after `docker-compose restart`
- [x] `docker-compose down -v` wipes volume
- [x] Volume appears in `docker volume ls`