### PR TITLE
Add Redis Container to Docker Compose

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -18,9 +18,26 @@ services:
       retries: 5
     restart: unless-stopped
 
+  redis:
+    image: redis:7-alpine
+    container_name: chatbot-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
 volumes:
   postgres_data_dev:
     name: chatbot_postgres_dev
+  redis_data:
+    name: chatbot_redis
 
 networks:
   default:


### PR DESCRIPTION
Add Redis container needed for background jobs and WebSocket support.

**Acceptance Criteria:**
- [ ] Redis service added to `docker-compose.yml`
- [ ] Uses `redis:7-alpine` image
- [ ] Exposes port 6379
- [ ] Named volume `redis_data` for persistence
- [ ] Healthcheck configured: `redis-cli ping`
- [ ] Can connect: `redis-cli -h localhost ping` returns PONG