### PR TITLE
Create Database Initialization SQL Script

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data_dev:/var/lib/postgresql/data
+      - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/01-init.sql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U chatbot_user -d chatbot_dev"]
       interval: 5s
@@ -28,6 +29,8 @@ services:
       POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --locale=en_US.UTF-8"
     ports:
       - "5433:5432"
+    volumes:
+      - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/01-init.sql
     tmpfs:
       - /var/lib/postgresql/data
     command: >

--- a/backend/scripts/init-db.sql
+++ b/backend/scripts/init-db.sql
@@ -1,0 +1,38 @@
+-- ============================================================================
+-- Database Initialization Script
+-- ============================================================================
+-- This script runs automatically when PostgreSQL container starts for the
+-- first time. It enables required extensions for the chatbot application.
+--
+-- Extensions:
+-- - uuid-ossp:         Generate UUIDs for primary keys
+-- - vector:            pgvector for similarity search
+-- - pg_stat_statements: Query performance monitoring
+--
+-- Note: This script is idempotent (safe to run multiple times)
+-- ============================================================================
+
+-- Enable UUID generation
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Enable pgvector for similarity search
+CREATE EXTENSION IF NOT EXISTS "vector";
+
+-- Enable query performance monitoring
+CREATE EXTENSION IF NOT EXISTS "pg_stat_statements";
+
+-- Verify extensions are installed
+DO $$
+DECLARE
+    ext_count INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO ext_count
+    FROM pg_extension
+    WHERE extname IN ('uuid-ossp', 'vector', 'pg_stat_statements');
+
+    IF ext_count = 3 THEN
+        RAISE NOTICE 'All required extensions installed successfully';
+    ELSE
+        RAISE WARNING 'Not all extensions installed. Expected 3, found %', ext_count;
+    END IF;
+END $$;


### PR DESCRIPTION
SQL script that runs automatically when PostgreSQL container starts first time. Enables required extensions.

**Acceptance Criteria:**
- [x] `scripts/init-db.sql` file created
- [x] Creates `uuid-ossp` extension
- [x] Creates `vector` extension
- [x] Creates `pg_stat_statements` extension
- [x] All commands use `CREATE EXTENSION IF NOT EXISTS` (idempotent)
- [x] Script mounted in `docker-compose.yml`: `/docker-entrypoint-initdb.d/01-init.sql`
- [x] Extensions load on first `docker-compose up`
- [x] Verified: `SELECT * FROM pg_extension;` shows all 3 extensions