### PR TITLE
Create Read-Only Database User

### DIFF
--- a/backend/scripts/init-db.sql
+++ b/backend/scripts/init-db.sql
@@ -2,14 +2,21 @@
 -- Database Initialization Script
 -- ============================================================================
 -- This script runs automatically when PostgreSQL container starts for the
--- first time. It enables required extensions for the chatbot application.
+-- first time. It enables required extensions and creates database users.
 --
 -- Extensions:
 -- - uuid-ossp:         Generate UUIDs for primary keys
 -- - vector:            pgvector for similarity search
 -- - pg_stat_statements: Query performance monitoring
 --
+-- Users:
+-- - chatbot_readonly:  Read-only access for analytics/reporting
+--
 -- Note: This script is idempotent (safe to run multiple times)
+-- ============================================================================
+
+-- ============================================================================
+-- EXTENSIONS
 -- ============================================================================
 
 -- Enable UUID generation
@@ -20,6 +27,46 @@ CREATE EXTENSION IF NOT EXISTS "vector";
 
 -- Enable query performance monitoring
 CREATE EXTENSION IF NOT EXISTS "pg_stat_statements";
+
+
+-- ============================================================================
+-- USERS AND PERMISSIONS
+-- ============================================================================
+
+-- Create read-only user for analytics and reporting
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_catalog.pg_user WHERE usename = 'chatbot_readonly') THEN
+        CREATE USER chatbot_readonly WITH PASSWORD 'readonly_pass';
+        RAISE NOTICE 'Created user: chatbot_readonly';
+    ELSE
+        RAISE NOTICE 'User chatbot_readonly already exists';
+    END IF;
+END
+$$;
+
+-- Grant connection permission
+GRANT CONNECT ON DATABASE chatbot_dev TO chatbot_readonly;
+
+-- Grant usage on public schema
+GRANT USAGE ON SCHEMA public TO chatbot_readonly;
+
+-- Grant SELECT on all existing tables
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO chatbot_readonly;
+
+-- Grant SELECT on all existing sequences (for viewing sequence values)
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO chatbot_readonly;
+
+-- Automatically grant SELECT on future tables
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO chatbot_readonly;
+
+-- Automatically grant SELECT on future sequences
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON SEQUENCES TO chatbot_readonly;
+
+
+-- ============================================================================
+-- VERIFICATION
+-- ============================================================================
 
 -- Verify extensions are installed
 DO $$
@@ -34,5 +81,24 @@ BEGIN
         RAISE NOTICE 'All required extensions installed successfully';
     ELSE
         RAISE WARNING 'Not all extensions installed. Expected 3, found %', ext_count;
+    END IF;
+END $$;
+
+-- Verify readonly user has correct permissions
+DO $$
+DECLARE
+    has_connect BOOLEAN;
+    has_usage BOOLEAN;
+BEGIN
+    -- Check CONNECT privilege
+    SELECT has_database_privilege('chatbot_readonly', current_database(), 'CONNECT') INTO has_connect;
+
+    -- Check USAGE privilege on schema
+    SELECT has_schema_privilege('chatbot_readonly', 'public', 'USAGE') INTO has_usage;
+
+    IF has_connect AND has_usage THEN
+        RAISE NOTICE 'Read-only user permissions configured successfully';
+    ELSE
+        RAISE WARNING 'Read-only user permissions incomplete';
     END IF;
 END $$;


### PR DESCRIPTION
Extend init-db.sql to create read-only user for analytics queries.

**Acceptance Criteria:**
- [x] init-db.sql creates `chatbot_readonly` user
- [x] Password: `readonly_pass`
- [x] Grants: CONNECT, USAGE on schema, SELECT on all tables
- [x] ALTER DEFAULT PRIVILEGES for future tables
- [x] Can connect: `psql -U chatbot_readonly -d chatbot_dev`
- [x] Can SELECT: `SELECT 1;` works
- [x] Cannot INSERT: `INSERT` fails with permission error