### PR TITLE
Use get_database_config() in settings files

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -80,13 +80,25 @@ TEMPLATES = [
 WSGI_APPLICATION = 'config.wsgi.application'
 ASGI_APPLICATION = 'config.asgi.application'
 
-# Database
+# ============================================================================
+# DATABASE CONFIGURATION
+# ============================================================================
+
+# Import database configuration module
+from config.settings.databases import get_database_config
+
+# Get environment from environment variable
+# Defaults to 'development' for local work
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'development')
+
+# Load database configuration for current environment
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-    }
+    'default': get_database_config(ENVIRONMENT)
 }
+
+# ============================================================================
+# END DATABASE CONFIGURATION
+# ============================================================================
 
 # Redis for channels
 CHANNEL_LAYERS = {


### PR DESCRIPTION
Update `config/settings/base.py` to use new database configuration module.

**Acceptance Criteria:**
- [ ] `base.py` imports `get_database_config` from databases module
- [ ] DATABASES dict uses: `get_database_config(ENVIRONMENT)`
- [ ] ENVIRONMENT read from env var: `os.getenv('ENVIRONMENT', 'development')`
- [ ] Removes old SQLite configuration
- [ ] Settings load without errors
- [ ] Can run: `python manage.py check --database default`