### PR TITLE
Create script to set up chatbot_app user with limited privileges

### DIFF
--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -1,0 +1,70 @@
+# Database Scripts
+
+## create-app-user.sql
+
+Creates the `chatbot_app` application user with minimal required privileges.
+
+### Usage
+
+```bash
+# As postgres superuser
+psql -h localhost -U postgres -d chatbot_dev -f scripts/create-app-user.sql
+
+# For production (update password in script first!)
+psql -h prod-host -U postgres -d chatbot_production -f scripts/create-app-user.sql
+```
+
+### What it does
+
+- Creates `chatbot_app` user (idempotent)
+- Grants CRUD on: documents, conversations, messages
+- Grants READ on: auth tables, django system tables
+- DENIES: DROP, CREATE, ALTER operations
+- Sets connection limit to 50
+
+### Testing
+
+```bash
+# Run permission tests
+psql -h localhost -U chatbot_app -d chatbot_dev -f scripts/test-app-user-permissions.sql
+
+# Or test manually
+psql -h localhost -U chatbot_app -d chatbot_dev
+
+# Try allowed operations
+SELECT * FROM documents_document LIMIT 5;
+INSERT INTO documents_document (...) VALUES (...);
+
+# Try denied operations (should fail)
+DROP TABLE documents_document;
+CREATE TABLE test (id INT);
+```
+
+### Security Notes
+
+- **CHANGE PASSWORD in production!** The default password is for development only
+- User cannot create/drop tables or users
+- User cannot modify schema
+- User has connection limit of 50
+- Consider enabling Row Level Security (RLS) for multi-tenant setups
+```
+
+**Test the script:**
+
+```bash
+cd backend
+
+# 1. Run the creation script
+psql -h localhost -p 5432 -U postgres -d chatbot_dev -f scripts/create-app-user.sql
+
+# 2. Run the test script
+psql -h localhost -p 5432 -U chatbot_app -d chatbot_dev -f scripts/test-app-user-permissions.sql
+
+# 3. Verify manually
+psql -h localhost -p 5432 -U chatbot_app -d chatbot_dev
+
+# Inside psql, test:
+# SELECT * FROM documents_document LIMIT 1;  -- Should work
+# DROP TABLE documents_document;              -- Should fail
+# CREATE TABLE test (id INT);                 -- Should fail
+```

--- a/backend/scripts/create-app-user.sql
+++ b/backend/scripts/create-app-user.sql
@@ -1,0 +1,147 @@
+-- =====================================================================
+-- Database Access Control Script
+-- Creates application user with minimal necessary privileges
+-- =====================================================================
+-- Purpose: Create chatbot_app user with CRUD access to application tables
+--          while preventing schema modifications
+-- Usage: psql -h localhost -U postgres -d chatbot_dev -f scripts/create-app-user.sql
+-- =====================================================================
+
+-- Enable required extensions (if not already enabled)
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- =====================================================================
+-- 1. Create Application User (Idempotent)
+-- =====================================================================
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT FROM pg_catalog.pg_roles WHERE rolname = 'chatbot_app'
+    ) THEN
+        CREATE ROLE chatbot_app WITH LOGIN PASSWORD 'app_secure_password_change_in_production';
+        RAISE NOTICE 'Created user: chatbot_app';
+    ELSE
+        RAISE NOTICE 'User chatbot_app already exists, skipping creation';
+    END IF;
+END
+$$;
+
+-- Set connection limit (optional security measure)
+ALTER ROLE chatbot_app CONNECTION LIMIT 50;
+
+-- =====================================================================
+-- 2. Grant Database Connection
+-- =====================================================================
+
+GRANT CONNECT ON DATABASE chatbot_dev TO chatbot_app;
+
+-- =====================================================================
+-- 3. Grant Schema Usage (Required for accessing tables)
+-- =====================================================================
+
+GRANT USAGE ON SCHEMA public TO chatbot_app;
+
+-- =====================================================================
+-- 4. Grant CRUD Privileges on Application Tables
+-- =====================================================================
+
+-- Documents tables
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE documents_document TO chatbot_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE documents_documentchunk TO chatbot_app;
+
+-- Chat tables
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE chat_conversation TO chatbot_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE chat_message TO chatbot_app;
+
+-- Auth tables (read-only for user lookups)
+GRANT SELECT ON TABLE auth_user TO chatbot_app;
+GRANT SELECT ON TABLE auth_group TO chatbot_app;
+GRANT SELECT ON TABLE auth_permission TO chatbot_app;
+
+-- Django system tables (read-only)
+GRANT SELECT ON TABLE django_migrations TO chatbot_app;
+GRANT SELECT ON TABLE django_content_type TO chatbot_app;
+GRANT SELECT ON TABLE django_session TO chatbot_app;
+
+-- =====================================================================
+-- 5. Grant Sequence Usage (Required for AUTO INCREMENT)
+-- =====================================================================
+
+-- Grant usage on all sequences for ID generation
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO chatbot_app;
+
+-- Make future sequences accessible
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+GRANT USAGE, SELECT ON SEQUENCES TO chatbot_app;
+
+-- =====================================================================
+-- 6. Explicitly DENY Schema Modification Privileges
+-- =====================================================================
+
+-- Revoke CREATE privilege on schema (prevents creating new tables)
+REVOKE CREATE ON SCHEMA public FROM chatbot_app;
+
+-- Note: By default, chatbot_app doesn't have these privileges, but we
+-- explicitly revoke them for documentation and defense-in-depth
+
+-- Revoke all privileges on database-level operations
+REVOKE CREATE ON DATABASE chatbot_dev FROM chatbot_app;
+
+-- =====================================================================
+-- 7. Row Level Security (Optional - Example for conversations)
+-- =====================================================================
+
+-- Uncomment if you want users to only see their own conversations
+-- ALTER TABLE chat_conversation ENABLE ROW LEVEL SECURITY;
+--
+-- CREATE POLICY conversation_isolation ON chat_conversation
+--     FOR ALL
+--     TO chatbot_app
+--     USING (user_id = current_setting('app.user_id')::INTEGER);
+
+-- =====================================================================
+-- 8. Grant Future Table Privileges (For migrations)
+-- =====================================================================
+
+-- Ensure new tables created by migrations are accessible
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO chatbot_app;
+
+-- =====================================================================
+-- 9. Verification Queries
+-- =====================================================================
+
+-- Show granted privileges
+\echo '=========================================='
+\echo 'Privileges granted to chatbot_app:'
+\echo '=========================================='
+
+SELECT
+    table_schema,
+    table_name,
+    string_agg(privilege_type, ', ' ORDER BY privilege_type) as privileges
+FROM information_schema.table_privileges
+WHERE grantee = 'chatbot_app'
+    AND table_schema = 'public'
+GROUP BY table_schema, table_name
+ORDER BY table_name;
+
+-- Show role attributes
+\echo ''
+\echo 'Role attributes:'
+SELECT
+    rolname,
+    rolsuper as is_superuser,
+    rolinherit as can_inherit,
+    rolcreaterole as can_create_roles,
+    rolcreatedb as can_create_db,
+    rolcanlogin as can_login,
+    rolconnlimit as connection_limit
+FROM pg_roles
+WHERE rolname = 'chatbot_app';
+
+\echo ''
+\echo 'Setup complete! Application user chatbot_app is ready.'
+\echo 'IMPORTANT: Change the password in production!'

--- a/backend/scripts/test-app-user-permissions.sql
+++ b/backend/scripts/test-app-user-permissions.sql
@@ -1,0 +1,137 @@
+-- =====================================================================
+-- Test Script for Application User Permissions
+-- =====================================================================
+-- Purpose: Verify chatbot_app can perform allowed operations
+--          and cannot perform denied operations
+-- Usage: psql -h localhost -U chatbot_app -d chatbot_dev -f scripts/test-app-user-permissions.sql
+-- =====================================================================
+
+\echo '=========================================='
+\echo 'Testing chatbot_app Permissions'
+\echo '=========================================='
+
+-- =====================================================================
+-- Test 1: CRUD Operations (Should SUCCEED)
+-- =====================================================================
+
+\echo ''
+\echo 'Test 1: Testing INSERT operation...'
+BEGIN;
+
+-- Insert test document
+INSERT INTO documents_document (
+    id, title, file_path, document_type, language,
+    processed, created_at, updated_at
+) VALUES (
+    gen_random_uuid(),
+    '[TEST] Permission Test Document',
+    '/tmp/test.pdf',
+    'manual',
+    'en',
+    true,
+    NOW(),
+    NOW()
+) RETURNING id, title;
+
+ROLLBACK;
+\echo '✓ INSERT successful'
+
+\echo ''
+\echo 'Test 2: Testing SELECT operation...'
+SELECT COUNT(*) as total_documents FROM documents_document;
+\echo '✓ SELECT successful'
+
+\echo ''
+\echo 'Test 3: Testing UPDATE operation...'
+BEGIN;
+
+UPDATE documents_document
+SET title = '[UPDATED] Test'
+WHERE title LIKE '[TEST]%'
+RETURNING id, title;
+
+ROLLBACK;
+\echo '✓ UPDATE successful'
+
+\echo ''
+\echo 'Test 4: Testing DELETE operation...'
+BEGIN;
+
+DELETE FROM documents_document
+WHERE title LIKE '[TEST]%'
+RETURNING id, title;
+
+ROLLBACK;
+\echo '✓ DELETE successful'
+
+-- =====================================================================
+-- Test 5: Schema Modification (Should FAIL)
+-- =====================================================================
+
+\echo ''
+\echo 'Test 5: Testing DROP TABLE (should fail)...'
+\set ON_ERROR_STOP off
+
+DROP TABLE documents_document;
+
+\set ON_ERROR_STOP on
+\echo '✓ DROP TABLE correctly denied'
+
+\echo ''
+\echo 'Test 6: Testing CREATE TABLE (should fail)...'
+\set ON_ERROR_STOP off
+
+CREATE TABLE test_malicious_table (id SERIAL PRIMARY KEY);
+
+\set ON_ERROR_STOP on
+\echo '✓ CREATE TABLE correctly denied'
+
+\echo ''
+\echo 'Test 7: Testing ALTER TABLE (should fail)...'
+\set ON_ERROR_STOP off
+
+ALTER TABLE documents_document ADD COLUMN malicious_column TEXT;
+
+\set ON_ERROR_STOP on
+\echo '✓ ALTER TABLE correctly denied'
+
+\echo ''
+\echo 'Test 8: Testing CREATE USER (should fail)...'
+\set ON_ERROR_STOP off
+
+CREATE ROLE malicious_user WITH LOGIN PASSWORD 'hacker';
+
+\set ON_ERROR_STOP on
+\echo '✓ CREATE USER correctly denied'
+
+-- =====================================================================
+-- Test 9: Sequence Access (Should SUCCEED)
+-- =====================================================================
+
+\echo ''
+\echo 'Test 9: Testing sequence access...'
+SELECT nextval('documents_document_id_seq');
+\echo '✓ Sequence access successful'
+
+-- =====================================================================
+-- Test 10: Auth Table Access (Should be READ-ONLY)
+-- =====================================================================
+
+\echo ''
+\echo 'Test 10: Testing auth_user SELECT (should succeed)...'
+SELECT COUNT(*) as total_users FROM auth_user;
+\echo '✓ auth_user SELECT successful'
+
+\echo ''
+\echo 'Test 11: Testing auth_user INSERT (should fail)...'
+\set ON_ERROR_STOP off
+
+INSERT INTO auth_user (username, password) VALUES ('hacker', 'password');
+
+\set ON_ERROR_STOP on
+\echo '✓ auth_user INSERT correctly denied'
+
+\echo ''
+\echo '=========================================='
+\echo 'All permission tests completed!'
+\echo '=========================================='


### PR DESCRIPTION
SQL script to create application user with minimal necessary permissions.

**Acceptance Criteria:**
- [ ] `scripts/create-app-user.sql` file created
- [ ] Creates `chatbot_app` user with password
- [ ] Grants CRUD on: conversations, messages, documents, document_chunks
- [ ] Denies: DROP, CREATE, ALTER on schema
- [ ] Script is idempotent (CREATE USER IF NOT EXISTS pattern)
- [ ] Tested: can INSERT/UPDATE/SELECT/DELETE from app tables
- [ ] Tested: cannot DROP tables or CREATE users