### PR TITLE
Replace primary blue with Swisson brand color (#e6000f)

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,4 @@
+// frontend/tailwind.config.js
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
@@ -8,8 +9,16 @@ export default {
     extend: {
       colors: {
         primary: {
-          600: '#0284c7',
-          700: '#0369a1',
+          50: '#fff1f1',
+          100: '#ffe1e1',
+          200: '#ffc7c7',
+          300: '#ffa0a0',
+          400: '#ff6969',
+          500: '#e6000f',  // Main Swisson brand color
+          600: '#c70010',  // Hover state
+          700: '#a80011',  // Active/pressed state
+          800: '#8a0012',  // Dark variant
+          900: '#6b0013',  // Darkest variant
         },
       },
     },


### PR DESCRIPTION
Update all primary colors throughout the app to use the official Swisson red.

**Acceptance Criteria:**
- [ ] `tailwind.config.js` - Update primary color palette
  ```javascript
  primary: {
    50: '#fee2e2',
    100: '#fecaca', 
    500: '#e6000f',  // Main brand color
    600: '#c70010',
    700: '#a80011',
    800: '#8a0012',
    900: '#6b0013',
  }
  ```
- [ ] Update all `bg-primary-600` and `text-primary-600` classes
- [ ] Update hover states to use darker red shades
- [ ] Update focus rings to red
- [ ] Verify color contrast meets WCAG AA standards
- [ ] Screenshot before/after for review